### PR TITLE
Add diffutils package to get cmp command

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -2,7 +2,7 @@ FROM fedora:31
 COPY 68k-diskdefs /tmp
 RUN \
   dnf update -y && \ 
-  dnf install -y wget xz gcc gcc-c++ gmp-devel mpfr-devel libmpc-devel make file texinfo srecord git libdsk java-11-openjdk unzip zip man vim-common && \
+  dnf install -y wget xz gcc gcc-c++ gmp-devel mpfr-devel libmpc-devel make file texinfo srecord git libdsk java-11-openjdk unzip zip man vim-common diffutils && \
   dnf clean all && \
   mkdir /opt/cpmtools && \
   cd /opt/cpmtools && \


### PR DESCRIPTION
Nice to have a Docker setup for these tools. 

Ran into missing 'cmp' command, so added diffutils to list of installed packages.

```
/bin/sh ../../gcc-9.2.0/gcc/../move-if-change tmp-tm.texi tm.texi
/bin/sh: cmp: command not found
```